### PR TITLE
검증 완수 업데이트, 리포트 요청 및 승인

### DIFF
--- a/src/admin/admin.service.ts
+++ b/src/admin/admin.service.ts
@@ -159,7 +159,7 @@ export class AdminService {
       .select('*');
 
     if (userError || adminRoleError || projectError) {
-      throw new Error('데이터를 가져오는 중 에러가 발생했습니다.');
+      throw new Error('데이터를 가져오는 중에 에러가 발생했습니다.');
     }
 
     const result = adminRoles.flatMap((adminRole) => {

--- a/src/poc/poc.service.ts
+++ b/src/poc/poc.service.ts
@@ -1,4 +1,10 @@
-import { Inject, Injectable, UnauthorizedException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ConflictException,
+  Inject,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
 import { SupabaseClient } from '@supabase/supabase-js';
 import { CreatePocDto } from './dto/create-poc.dto';
 import { CreateTaskDto } from './dto/create-task-dto';
@@ -21,7 +27,9 @@ export class PocService {
     }
 
     if (findAdminError) {
-      throw new Error(`어드민 검사 에러 ${findAdminError.message}`);
+      throw new BadRequestException(
+        `어드민 검사 에러 ${findAdminError.message}`,
+      );
     }
 
     const { data: pocData, error: pocDataError } = await this.supabase
@@ -40,7 +48,7 @@ export class PocService {
       .single();
 
     if (pocDataError) {
-      throw new Error(`POC 생성 에러: ${pocDataError.message}`);
+      throw new BadRequestException(`POC 생성 에러: ${pocDataError.message}`);
     }
     return pocData;
   }
@@ -50,6 +58,17 @@ export class PocService {
     userId: string,
     pocId: string,
   ) {
+    if (createTaskDto.projectId) {
+      const { data: checkUserProject } = await this.supabase
+        .from('project_member')
+        .select()
+        .eq('project_id', createTaskDto.projectId)
+        .eq('members_id', userId)
+        .single();
+      if (!checkUserProject) {
+        throw new ConflictException(`해당 프로젝트의 참여자가 아닙니다.`);
+      }
+    }
     const { data: taskData, error: taskError } = await this.supabase
       .from('task')
       .insert([
@@ -65,7 +84,7 @@ export class PocService {
       .single();
 
     if (taskError) {
-      throw new Error(`task 생성 에러: ${taskError.message}`);
+      throw new BadRequestException(`task 생성 에러: ${taskError.message}`);
     }
 
     return taskData;

--- a/src/poc/poc.service.ts
+++ b/src/poc/poc.service.ts
@@ -1,6 +1,5 @@
 import {
   BadRequestException,
-  ConflictException,
   Inject,
   Injectable,
   UnauthorizedException,
@@ -66,7 +65,7 @@ export class PocService {
         .eq('members_id', userId)
         .single();
       if (!checkUserProject) {
-        throw new ConflictException(`해당 프로젝트의 참여자가 아닙니다.`);
+        throw new UnauthorizedException(`해당 프로젝트의 참여자가 아닙니다.`);
       }
     }
     const { data: taskData, error: taskError } = await this.supabase

--- a/src/report/report.controller.ts
+++ b/src/report/report.controller.ts
@@ -1,0 +1,33 @@
+import {
+  Body,
+  Controller,
+  Param,
+  Patch,
+  Post,
+  Request,
+  UseGuards,
+} from '@nestjs/common';
+import { AuthGuard } from 'src/auth/guards/auth.guard';
+import { ReportService } from './report.service';
+import { CreateReportDto, UpdateReportDto } from './report.dto';
+
+@Controller('report')
+@UseGuards(AuthGuard)
+export class ReportController {
+  constructor(private readonly reportService: ReportService) {}
+  @Post()
+  async CreateReport(@Body() createReportDto: CreateReportDto, @Request() req) {
+    const userId = req.user.userId;
+    return this.reportService.createReport(createReportDto, userId);
+  }
+
+  @Patch(':reportId')
+  async updateReport(
+    @Body() updateReportDto: UpdateReportDto,
+    @Request() req,
+    @Param('reportId') reportId,
+  ) {
+    const userId = req.user.userId;
+    return this.reportService.updateReport(updateReportDto, userId, reportId);
+  }
+}

--- a/src/report/report.dto.ts
+++ b/src/report/report.dto.ts
@@ -1,0 +1,20 @@
+import { IsString, IsUUID } from 'class-validator';
+
+export class CreateReportDto {
+  @IsString()
+  content: string;
+
+  @IsUUID()
+  validationId: string;
+
+  @IsString()
+  stakingContractAddress: string;
+
+  @IsUUID()
+  adminId: string;
+}
+
+export class UpdateReportDto {
+  @IsString()
+  responseComment: string;
+}

--- a/src/report/report.module.ts
+++ b/src/report/report.module.ts
@@ -1,4 +1,12 @@
 import { Module } from '@nestjs/common';
+import { AuthModule } from 'src/auth/auth.module';
+import { ReportController } from './report.controller';
+import { ReportService } from './report.service';
 
-@Module({})
+@Module({
+  imports: [AuthModule],
+  controllers: [ReportController],
+  providers: [ReportService],
+  exports: [ReportService],
+})
 export class ReportModule {}

--- a/src/report/report.service.ts
+++ b/src/report/report.service.ts
@@ -1,0 +1,126 @@
+import {
+  Injectable,
+  Inject,
+  BadRequestException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { SupabaseClient } from '@supabase/supabase-js';
+import { CreateReportDto, UpdateReportDto } from './report.dto';
+
+@Injectable()
+export class ReportService {
+  constructor(
+    @Inject('SUPABASE_CLIENT')
+    private readonly supabase: SupabaseClient,
+  ) {}
+
+  async createReport(createReportDto: CreateReportDto, userId: string) {
+    const { data: userData, error: userError } = await this.supabase
+      .from('user')
+      .select()
+      .eq('id', userId)
+      .single();
+    if (!userData || !userData.approved_at) {
+      throw new UnauthorizedException(`리포트를 등록할 권한이 없습니다.`);
+    }
+    if (userError) {
+      throw new BadRequestException(
+        `사용자의 승인 여부를 검사하는 중에 에러가 발생하였습니다.: ${userError.message}`,
+      );
+    }
+    const { data: reportData, error: reportError } = await this.supabase
+      .from('report')
+      .insert([
+        {
+          user_id: userId,
+          content: createReportDto.content,
+          staking_contract_address: createReportDto.stakingContractAddress,
+          admin_id: createReportDto.adminId,
+          status: 'No response',
+          validation_id: createReportDto.validationId,
+        },
+      ])
+      .select()
+      .single();
+
+    if (reportError) {
+      throw new BadRequestException(`리포트 등록 에러: ${reportError.message}`);
+    }
+    return reportData;
+  }
+
+  async updateReport(
+    updateReportDto: UpdateReportDto,
+    userId: string,
+    reportId: string,
+  ) {
+    const { data: adminData, error: adminError } = await this.supabase
+      .from('admin')
+      .select()
+      .eq('user_id', userId)
+      .single();
+    if (!adminData) {
+      throw new UnauthorizedException(`어드민이 아닙니다.`);
+    }
+    if (adminError) {
+      throw new BadRequestException(
+        `어드민 조회 중 에러가 발생하였습니다.: ${adminError.message}`,
+      );
+    }
+    const adminId = adminData.id;
+    const { data: reportAdminData, error: reportAdminError } =
+      await this.supabase
+        .from('report')
+        .select()
+        .eq('admin_id', adminId)
+        .eq('id', reportId)
+        .single();
+    if (!reportAdminData) {
+      throw new UnauthorizedException(`리포트 요청 받은 어드민이 아닙니다.`);
+    }
+
+    if (reportAdminError) {
+      throw new BadRequestException(
+        `어드민 확인 중에 에러가 발생했습니다.: ${adminError.message}`,
+      );
+    }
+    console.log(updateReportDto.responseComment);
+    const { data: reportData, error: reportError } = await this.supabase
+      .from('report')
+      .update({
+        status: 'approved',
+        response_comment: updateReportDto.responseComment,
+      })
+      .eq('id', reportId)
+      .select()
+      .single();
+
+    if (reportError) {
+      throw new BadRequestException(
+        `리포트 승인 중에 에러가 발생하였습니다.: ${reportError.message}`,
+      );
+    }
+
+    const validationId = reportData.validation_id;
+    console.log(validationId);
+    const { data: validationData, error: validationError } = await this.supabase
+      .from('validation')
+      .update({
+        status: 'reject',
+      })
+      .eq('id', validationId)
+      .select()
+      .single();
+    if (validationError) {
+      throw new BadRequestException(
+        `검증 업데이트 중에 에러가 발생하였습니다.: ${validationError.message}`,
+      );
+    }
+
+    const formattedData = {
+      ...reportData,
+      updatedvalidationData: { ...validationData },
+    };
+    return formattedData;
+  }
+}

--- a/src/validate/validate.controller.ts
+++ b/src/validate/validate.controller.ts
@@ -1,10 +1,19 @@
-import { Body, Controller, Post, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Param,
+  Patch,
+  Post,
+  Request,
+  UseGuards,
+} from '@nestjs/common';
 import { AuthGuard } from 'src/auth/guards/auth.guard';
 import { ValidateService } from './validate.service';
 import {
   CreateValidationDto,
   CreateValidatorDto,
-} from './dto/create-validate-dto';
+  UpdateValidationDto,
+} from './validate.dto';
 
 @Controller('validate')
 @UseGuards(AuthGuard)
@@ -22,5 +31,19 @@ export class ValidateController {
   ) {
     // const userId = req.user.userId;
     return this.validateService.createValidation(createValidationDto);
+  }
+
+  @Patch('validation/:validationId')
+  async UpdateValidation(
+    @Body() updateValidationDto: UpdateValidationDto,
+    @Request() req,
+    @Param('validationId') validationId,
+  ) {
+    const userId = req.user.userId;
+    return this.validateService.updateValidation(
+      updateValidationDto,
+      userId,
+      validationId,
+    );
   }
 }

--- a/src/validate/validate.dto.ts
+++ b/src/validate/validate.dto.ts
@@ -8,5 +8,13 @@ export class CreateValidationDto {
 
 export class CreateValidatorDto {
   @IsString()
-  stakingContractAddress: string;
+  walletAddress: string;
+}
+
+export class UpdateValidationDto {
+  @IsString()
+  comment: string;
+
+  @IsString()
+  rewardContractAddress: string;
 }


### PR DESCRIPTION
### 검증 완수 업데이트
![스크린샷 2025-02-05 234849](https://github.com/user-attachments/assets/b27d957d-05e3-4a95-ae55-ea7ba7f742d1)
- 해당 검증을 담당한 검증인만이 검증 상태를 완수(pending -> success)로 업데이트할 수 있도록 함.
- 보상 컨트랙트 주소도 업데이트.
### 리포트 요청
![스크린샷 2025-02-05 234827](https://github.com/user-attachments/assets/cd6f12bb-b646-4540-8315-8108de313724)
- 특정 검증에 대한 리포트를 요청함.
- 승인받은 사용자만이 리포트를 요청할 수 있도록 함.
- 어드민 및 스테이킹 컨트랙트 주소를 지정해서 보냄.
### 리포트 승인 
![스크린샷 2025-02-05 234804](https://github.com/user-attachments/assets/d1de8a23-d268-44e6-bebd-6e3c4b4fb26d)
- 리포트 요청 시 할당받은 어드민이 리포트를 승인(No response -> approve)할 수 있도록 함.
- 동시에 해당 검증의 상태가 reported로 업데이트됨(success -> reported).

++
태스크 등록 시 해당 프로젝트의 참여자들만 태스크를 생성할 수 있도록 유효성 검사 추가함.
![image](https://github.com/user-attachments/assets/3a8a95b0-29d9-4233-a6d4-9252b946bdee)
- 프로젝트의 참여자가 아닐 경우 위처럼 에러 메시지가 뜸.
  ```
  if (createTaskDto.projectId) {
    const { data: checkUserProject } = await this.supabase
      .from('project_member')
      .select()
      .eq('project_id', createTaskDto.projectId)
      .eq('members_id', userId)
      .single();
    if (!checkUserProject) {
      throw new UnauthorizedException(`해당 프로젝트의 참여자가 아닙니다.`);
    }
  }
  ...
  ```