### PR TITLE
검증 기간 / 리포트 기간이 지난 검증 상태 자동 업데이트

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@nestjs/core": "^10.4.12",
     "@nestjs/jwt": "^10.2.0",
     "@nestjs/platform-express": "^10.0.0",
+    "@nestjs/schedule": "^5.0.1",
     "@nestjs/swagger": "^8.0.7",
     "@pinata/sdk": "^2.1.0",
     "@supabase/supabase-js": "^2.46.2",

--- a/src/epoch/epoch.service.ts
+++ b/src/epoch/epoch.service.ts
@@ -79,6 +79,12 @@ export class EpochService {
     return data;
   }
 
+  // async getEpochList() {
+  //   const { data: epochListData, error: epochListError } = await this.supabase
+  //     .from('epoch')
+  //     .select(``);
+  // }
+
   async getCurrentEpoch() {
     const { data, error } = await this.supabase
       .from('epochs')

--- a/src/project/dto/approve-project.dto.ts
+++ b/src/project/dto/approve-project.dto.ts
@@ -1,4 +1,4 @@
-import { IsUUID, IsBoolean, IsOptional, IsString } from 'class-validator';
+import { IsUUID, IsOptional, IsString } from 'class-validator';
 
 export class ApproveProjectDto {
   @IsUUID()

--- a/src/project/project.service.ts
+++ b/src/project/project.service.ts
@@ -164,7 +164,7 @@ export class ProjectService {
     if (!project.approve_status) throw new Error('Project is not approved');
 
     // 2️⃣ 중복된 레포지토리 링크 여부 확인
-    const { data: existingRepo, error: repoError } = await supabase
+    const { data: existingRepo } = await supabase
       .from('repository')
       .select('repo_link')
       .eq('project_id', dto.project_id)

--- a/src/report/report.service.ts
+++ b/src/report/report.service.ts
@@ -106,7 +106,7 @@ export class ReportService {
     const { data: validationData, error: validationError } = await this.supabase
       .from('validation')
       .update({
-        status: 'reject',
+        status: 'reported',
       })
       .eq('id', validationId)
       .select()

--- a/src/validate/validate.module.ts
+++ b/src/validate/validate.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { AuthModule } from 'src/auth/auth.module';
 import { ValidateController } from './validate.controller';
 import { ValidateService } from './validate.service';
+import { ScheduleModule } from '@nestjs/schedule';
 
 @Module({
-  imports: [AuthModule],
+  imports: [AuthModule, ScheduleModule.forRoot()],
   controllers: [ValidateController],
   providers: [ValidateService],
   exports: [ValidateService],

--- a/src/validate/validate.service.ts
+++ b/src/validate/validate.service.ts
@@ -3,6 +3,10 @@ import {
   Inject,
   BadRequestException,
   UnauthorizedException,
+  Logger,
+  OnModuleInit,
+  NotFoundException,
+  InternalServerErrorException,
 } from '@nestjs/common';
 import { SupabaseClient } from '@supabase/supabase-js';
 import {
@@ -12,12 +16,78 @@ import {
 } from './validate.dto';
 
 @Injectable()
-export class ValidateService {
+export class ValidateService implements OnModuleInit {
+  private readonly logger = new Logger(ValidateService.name);
+  private activeTimers = new Map<string, NodeJS.Timeout>();
+
   constructor(
     @Inject('SUPABASE_CLIENT')
     private readonly supabase: SupabaseClient,
   ) {}
 
+  // 검증 기간 카운트 타이머 초기화
+  async onModuleInit() {
+    this.logger.log('리포트 기간 카운트 타이머 초기화');
+
+    // 상태가 pending인 검증 조회
+    const { data: pendingValidations } = await this.supabase
+      .from('validation')
+      .select()
+      .eq('status', 'pending');
+
+    // pending인 검증들의 검증 기간 타이머 설정
+    for (const vali of pendingValidations) {
+      const currentTimeMinusCreatedAt =
+        new Date().getTime() - new Date(vali.created_at).getTime(); // 현재 시간 - 검증 생성 시간
+      const remainingTime = 60 * 1000 - currentTimeMinusCreatedAt; // 타이머의 남은 시간 계산
+
+      if (remainingTime > 0) {
+        // 타이머 시간이 아직 남았다면 검증 기간의 남은 기간 재설정
+        this.setValidationPeriodTimer(vali.id, remainingTime);
+      } else {
+        // 타이머를 초과했다면 검증인 재할당
+        await this.reassignValidator(vali.id);
+      }
+    }
+
+    // 상태가 validating인 검증 조회
+    const { data: successValidations } = await this.supabase
+      .from('validation')
+      .select()
+      .eq('status', 'validating');
+
+    for (const vali of successValidations) {
+      const currentTimeMinusCreatedAt =
+        new Date().getTime() - new Date(vali.created_at).getTime(); // 현재 시간 - 검증 생성 시간
+      const remainingTime = 60 * 1000 - currentTimeMinusCreatedAt; // 타이머의 남은 시간 계산
+
+      if (remainingTime > 0) {
+        // 타이머 시간이 아직 남았다면 리포트의 남은 기간 재설정
+        this.setReportPeriodTimer(vali.id, remainingTime);
+      } else {
+        // 타이머를 초과했다면 검증 success로 업데이트
+        this.updateValidationSuccess(vali.id);
+      }
+    }
+  }
+
+  // 리포트 기간이 지난 validating 검증 업데이트
+  async updateValidationSuccess(validationId: string) {
+    const { error: validationError } = await this.supabase
+      .from('validation')
+      .update({
+        status: 'success',
+      })
+      .eq('id', validationId);
+
+    if (validationError) {
+      this.logger.error(
+        `검증 상태를 변경하던 중에 에러가 발생하였습니다.: ${validationError.message}`,
+      );
+    }
+  }
+
+  // 검증인 등록
   async createValidator(createValidatorDto: CreateValidatorDto) {
     const { data: contractAddressOwner, error: contractAddressOwnerError } =
       await this.supabase
@@ -27,8 +97,12 @@ export class ValidateService {
         .single();
 
     if (contractAddressOwnerError) {
-      throw new Error(`검증인 찾기 에러: ${contractAddressOwnerError.message}`);
+      throw new InternalServerErrorException(
+        `검증인 조회 중 에러가 발생하였습니다.: ${contractAddressOwnerError.message}`,
+      );
     }
+
+    // 검증인 등록
     const { data: validatorData, error: validatorError } = await this.supabase
       .from('validator')
       .insert([
@@ -39,30 +113,217 @@ export class ValidateService {
       ])
       .select('*')
       .single();
-    if (validatorError) throw new Error(`${validatorError.message}`);
-    console.log(validatorData);
+
+    if (validatorError)
+      throw new InternalServerErrorException(
+        `검증인 조회 중 에러가 발생하였습니다.: ${validatorError.message}`,
+      );
+
     return validatorData;
   }
 
+  // 검증 생성
   async createValidation(createValidationDto: CreateValidationDto) {
+    // 프로젝트 참여자들 조회
+    const projectMembers = await this.findProjectMembers(
+      createValidationDto.taskId,
+    );
+
+    // 유효한 검증인 조회
+    const validValidator = await this.findValidValidator(projectMembers);
+
+    // pending인 검증 조회
+    const { data: validationData, error: validationError } = await this.supabase
+      .from('validation')
+      .insert([
+        {
+          vali_id: validValidator,
+          status: 'pending',
+          task_id: createValidationDto.taskId,
+        },
+      ])
+      .select()
+      .single();
+
+    if (validationError) {
+      throw new Error(`검증 에러: ${validationError.message}`);
+    }
+
+    // 검증 생성과 동시에 타이머 설정 (시작)
+    this.setValidationPeriodTimer(validationData.id, 60 * 1000);
+
+    return validationData;
+  }
+
+  // 타이머(검증 기간) 설정
+  private setValidationPeriodTimer(
+    validationId: string,
+    validationPeriod: number,
+  ) {
+    this.logger.log(
+      `검증 ID에 대한 timeout 설정: 검증 ID - ${validationId} / timeout - ${validationPeriod / 1000}s`,
+    );
+
+    // 지정된 시간(24시간)이 지나면 검증인 재할당
+    const timeout = setTimeout(async () => {
+      await this.reassignValidator(validationId);
+    }, validationPeriod);
+
+    this.activeTimers.set(validationId, timeout);
+  }
+
+  // 타이머(리포트 기간) 설정
+  private setReportPeriodTimer(validationId: string, reportPeriod: number) {
+    this.logger.log(
+      `검증 ID에 대한 timeout 설정: 검증 ID - ${validationId} / timeout - ${reportPeriod / 1000}s`,
+    );
+
+    // 지정된 시간(24시간)이 지나면 검증인 재할당
+    const timeout = setTimeout(async () => {
+      await this.updateValidationSuccess(validationId);
+    }, reportPeriod);
+
+    this.activeTimers.set(validationId, timeout);
+  }
+
+  // 검증인 재할당
+  private async reassignValidator(validationId: string) {
+    // validationId에 해당하는 검증 조회
+    const { data: validationData, error: validationError } = await this.supabase
+      .from('validation')
+      .select()
+      .eq('id', validationId)
+      .single();
+
+    if (validationError) {
+      this.logger.error(
+        `검증 조회 중 에러가 발생하였습니다.: ${validationError.message}`,
+      );
+    }
+    const validator = validationData.vali_id; // 리포트 기간이 지난 검증의 검증인
+
+    // 프로젝트 참여자들 조회
+    const projectMembers = await this.findProjectMembers(
+      validationData.task_id,
+    );
+
+    // 프로젝트 참여자들과 현재 검증인을 한 배열로 묶음
+    const currnetValidatorProjectMembers = [
+      ...new Set([...projectMembers, validator]),
+    ];
+
+    // 유효한 검증인 조회
+    const validValidator = await this.findValidValidator(
+      currnetValidatorProjectMembers,
+    );
+
+    // 검증인 재할당
+    const { data: valiData, error: valiError } = await this.supabase
+      .from('validation')
+      .update([
+        {
+          vali_id: validValidator,
+          created_at: new Date(),
+        },
+      ])
+      .eq('id', validationId)
+      .select()
+      .single();
+
+    if (valiError) {
+      throw new Error(`검증 에러: ${valiError.message}`);
+    }
+
+    // 검증인 및 created_at 업데이트하고 타이머 재시작
+    this.setValidationPeriodTimer(validationId, 60 * 1000);
+    return valiData;
+  }
+
+  // 검증 업데이트 (검증인이 테스크 완수 인정)
+  async updateValidation(
+    updateValidationDto: UpdateValidationDto,
+    userId: string,
+    validationId: string,
+  ) {
+    // 해당 검증 조회
+    const { data: validationData, error: validationError } = await this.supabase
+      .from('validation')
+      .select()
+      .eq('id', validationId)
+      .single();
+    if (validationError) {
+      throw new BadRequestException(
+        `검증 조회 중에 에러가 발생하였습니다.: ${validationError.message}`,
+      );
+    }
+    const validatorId = validationData.vali_id;
+
+    // 해당 검증의 검증인 조회
+    const { data: checkValidator, error: checkValidatorError } =
+      await this.supabase
+        .from('validator')
+        .select()
+        .eq('id', validatorId)
+        .single();
+
+    // 현재 사용자가 검증인인지 확인
+    if (checkValidator.user_id != userId) {
+      throw new UnauthorizedException('검증인이 아닙니다.');
+    }
+    if (checkValidatorError) {
+      throw new BadRequestException(
+        `검증인 확인 중에 에러가 발생하였습니다.: ${checkValidatorError.message}`,
+      );
+    }
+
+    // 테스크 완수 인정
+    const { data: updateValidationData, error: updateValidationError } =
+      await this.supabase
+        .from('validation')
+        .update({
+          status: 'validating',
+          comment: updateValidationDto.comment,
+          reward_contract_address: updateValidationDto.rewardContractAddress,
+          created_at: new Date(),
+        })
+        .eq('id', validationId)
+        .select()
+        .single();
+
+    if (updateValidationError) {
+      throw new BadRequestException(
+        `검증 완수 업데이트 중에 에러가 발생하였습니다.: ${updateValidationError.message}`,
+      );
+    }
+
+    // 검증 업데이트와 동시에 리포트 기간 시작
+    this.setReportPeriodTimer(validationId, 60 * 1000);
+
+    return updateValidationData;
+  }
+
+  // 프로젝트 참여자들 조회 (필터링하기 위함)
+  async findProjectMembers(taskId: string) {
     // 검증 요청한 테스크의 프로젝트 ID 찾기
     const { data: projectData, error: projectError } = await this.supabase
       .from('task')
       .select()
-      .eq('id', createValidationDto.taskId)
+      .eq('id', taskId)
       .single();
     if (projectError) {
-      throw new Error(`프로젝트 ID 찾기 에러: ${projectError.message}`);
+      throw new BadRequestException(
+        `프로젝트 ID 조회 에러: ${projectError.message}`,
+      );
     }
     const projectId = projectData.project_id;
 
-    // 프로젝트 참여자(리더) ID 찾기
+    // 프로젝트 참여자(리더) ID 조회
     const projectLeader = (
       await this.supabase.from('project').select().eq('id', projectId).single()
     ).data;
     const leaderId = projectLeader.id;
 
-    // 프로젝트 참여자(리더 X) ID 찾기 (1명 이상)
+    // 프로젝트 참여자(리더 X) ID 조회 (1명 이상)
     const projectMembers =
       (
         await this.supabase
@@ -75,19 +336,28 @@ export class ValidateService {
     // 프로젝트 참여자들을 한 배열로 묶음
     const projectMemberLeaderId = [...new Set([...projectMemberId, leaderId])];
 
-    // 프로젝트에 참여하지 않은 검증인 찾기
+    return projectMemberLeaderId;
+  }
+
+  // 유효한 검증인 조회
+  async findValidValidator(notValidValidators: string[]) {
+    // 프로젝트에 참여하지 않은 검증인 조회
     const { data: validatorData, error: validatorError } = await this.supabase
       .from('validator')
       .select();
     if (validatorError) {
-      throw new Error(`검증인 불러오기 에러: ${validatorError.message}`);
+      throw new BadRequestException(
+        `검증인 불러오기 에러: ${validatorError.message}`,
+      );
     }
     const validatorIds = validatorData.map((valid) => valid.id);
+
     // 프로젝트에 참여하지 않은 검증인 필터링
     const availableValidators = validatorIds.filter(
-      (validatorId) => !projectMemberLeaderId.includes(validatorId),
+      (validatorId) => !notValidValidators.includes(validatorId),
     );
 
+    // 최종적으로 검증인을 랜덤으로 지정
     const randomValidator =
       availableValidators.length > 0
         ? availableValidators[
@@ -95,72 +365,9 @@ export class ValidateService {
           ]
         : null;
     if (randomValidator === null) {
-      throw new Error(`적절한 검증인 없음`);
+      throw new NotFoundException(`적절한 검증인이 없습니다.`);
     }
 
-    const { data: validationData, error: validationError } = await this.supabase
-      .from('validation')
-      .insert([
-        {
-          vali_id: randomValidator,
-          status: 'pending',
-        },
-      ])
-      .select()
-      .single();
-
-    if (validationError) {
-      throw new Error(`검증 에러: ${validationError.message}`);
-    }
-    return validationData;
-  }
-
-  async updateValidation(
-    updateValidationDto: UpdateValidationDto,
-    userId: string,
-    validationId: string,
-  ) {
-    const { data: validationData, error: validationError } = await this.supabase
-      .from('validation')
-      .select()
-      .eq('id', validationId)
-      .single();
-    if (validationError) {
-      throw new BadRequestException(
-        `검증 조회 중에 에러가 발생하였습니다.: ${validationError.message}`,
-      );
-    }
-    const validatorId = validationData.vali_id;
-    const { data: checkValidator, error: checkValidatorError } =
-      await this.supabase
-        .from('validator')
-        .select()
-        .eq('id', validatorId)
-        .single();
-    if (checkValidator.user_id != userId) {
-      throw new UnauthorizedException('검증인이 아닙니다.');
-    }
-    if (checkValidatorError) {
-      throw new BadRequestException(
-        `검증인 확인 중에 에러가 발생하였습니다.: ${checkValidatorError.message}`,
-      );
-    }
-    const { data: updateValidationData, error: updateValidationError } =
-      await this.supabase
-        .from('validation')
-        .update({
-          status: 'success',
-          comment: updateValidationDto.comment,
-          reward_contract_address: updateValidationDto.rewardContractAddress,
-        })
-        .eq('id', validationId)
-        .select()
-        .single();
-    if (updateValidationError) {
-      throw new BadRequestException(
-        `검증 완수 업데이트 중에 에러가 발생하였습니다.: ${updateValidationError.message}`,
-      );
-    }
-    return updateValidationData;
+    return randomValidator;
   }
 }

--- a/src/validate/validate.service.ts
+++ b/src/validate/validate.service.ts
@@ -39,7 +39,7 @@ export class ValidateService implements OnModuleInit {
     for (const vali of pendingValidations) {
       const currentTimeMinusCreatedAt =
         new Date().getTime() - new Date(vali.created_at).getTime(); // 현재 시간 - 검증 생성 시간
-      const remainingTime = 60 * 1000 - currentTimeMinusCreatedAt; // 타이머의 남은 시간 계산
+      const remainingTime = 24 * 60 * 60 * 1000 - currentTimeMinusCreatedAt; // 타이머의 남은 시간 계산
 
       if (remainingTime > 0) {
         // 타이머 시간이 아직 남았다면 검증 기간의 남은 기간 재설정
@@ -59,7 +59,7 @@ export class ValidateService implements OnModuleInit {
     for (const vali of successValidations) {
       const currentTimeMinusCreatedAt =
         new Date().getTime() - new Date(vali.created_at).getTime(); // 현재 시간 - 검증 생성 시간
-      const remainingTime = 60 * 1000 - currentTimeMinusCreatedAt; // 타이머의 남은 시간 계산
+      const remainingTime = 24 * 60 * 60 * 1000 - currentTimeMinusCreatedAt; // 타이머의 남은 시간 계산
 
       if (remainingTime > 0) {
         // 타이머 시간이 아직 남았다면 리포트의 남은 기간 재설정
@@ -150,7 +150,7 @@ export class ValidateService implements OnModuleInit {
     }
 
     // 검증 생성과 동시에 타이머 설정 (시작)
-    this.setValidationPeriodTimer(validationData.id, 60 * 1000);
+    this.setValidationPeriodTimer(validationData.id, 24 * 60 * 60 * 1000);
 
     return validationData;
   }
@@ -235,7 +235,7 @@ export class ValidateService implements OnModuleInit {
     }
 
     // 검증인 및 created_at 업데이트하고 타이머 재시작
-    this.setValidationPeriodTimer(validationId, 60 * 1000);
+    this.setValidationPeriodTimer(validationId, 24 * 60 * 60 * 1000);
     return valiData;
   }
 
@@ -297,7 +297,7 @@ export class ValidateService implements OnModuleInit {
     }
 
     // 검증 업데이트와 동시에 리포트 기간 시작
-    this.setReportPeriodTimer(validationId, 60 * 1000);
+    this.setReportPeriodTimer(validationId, 24 * 60 * 60 * 1000);
 
     return updateValidationData;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -755,6 +755,13 @@
     multer "1.4.4-lts.1"
     tslib "2.8.1"
 
+"@nestjs/schedule@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@nestjs/schedule/-/schedule-5.0.1.tgz#7704132a3909387abebf9241bee913cbf53e8d1e"
+  integrity sha512-kFoel84I4RyS2LNPH6yHYTKxB16tb3auAEciFuc788C3ph6nABkUfzX5IE+unjVaRX+3GuruJwurNepMlHXpQg==
+  dependencies:
+    cron "3.5.0"
+
 "@nestjs/schematics@^10.0.0", "@nestjs/schematics@^10.0.1":
   version "10.2.3"
   resolved "https://registry.npmjs.org/@nestjs/schematics/-/schematics-10.2.3.tgz"
@@ -1150,6 +1157,11 @@
   version "4.0.2"
   resolved "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz"
   integrity sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==
+
+"@types/luxon@~3.4.0":
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/@types/luxon/-/luxon-3.4.2.tgz#e4fc7214a420173cea47739c33cdf10874694db7"
+  integrity sha512-TifLZlFudklWlMBfhubvgqTXRzLDI5pCbGa4P8a3wPyUQSW+1xQ5eDsreP9DWHX3tjq1ke96uYG/nwundroWcA==
 
 "@types/methods@^1.1.4":
   version "1.1.4"
@@ -2222,6 +2234,14 @@ create-require@^1.1.0:
   version "1.1.1"
   resolved "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
+
+cron@3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/cron/-/cron-3.5.0.tgz#e8caa384e998ed275e19598df4dbd0e8578c35d9"
+  integrity sha512-0eYZqCnapmxYcV06uktql93wNWdlTmmBFP2iYz+JPVcQqlyFYcn1lFuIk4R54pkOmE7mcldTAPZv6X5XA4Q46A==
+  dependencies:
+    "@types/luxon" "~3.4.0"
+    luxon "~3.5.0"
 
 cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.6"
@@ -4151,6 +4171,11 @@ lru-cache@^5.1.1:
   integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
   dependencies:
     yallist "^3.0.2"
+
+luxon@~3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/luxon/-/luxon-3.5.0.tgz#6b6f65c5cd1d61d1fd19dbf07ee87a50bf4b8e20"
+  integrity sha512-rh+Zjr6DNfUYR3bPwJEnuwDdqMbxZW7LOQfUN4B54+Cl+0o5zaU9RJ6bcidfDtC1cWCZXQ+nvX8bf6bAji37QQ==
 
 mafmt@^7.0.0:
   version "7.1.0"


### PR DESCRIPTION
- pending인 검증들에 한해서, 검증 기간(24시간)이 지나면 검증인을 변경합니다.
  https://github.com/user-attachments/assets/c8a0df73-8c42-47a1-976e-740b2a347f72 
  - 검증인은 현재 검증인과 프로젝트 참여자들을 제외한 검증인들 중 랜덤으로 지정하였습니다. 
  - 검증인이 변경될 때 created_at을 현재 시간으로 업데이트하여 다시 검증 기간 타이머가 재시작되도록 하였습니다.
- validating인 검증들에 한해서, 리포트 기간(24시간)이 지나면 검증의 상태를 success로 변경합니다. 
  https://github.com/user-attachments/assets/9d95350e-2418-4f53-954e-2c06c32dd244
 
- 영상에선 실행 결과를 확인하기 위해 타이머를 임의적으로 1분으로 맞춰놓고 테스트했습니다. (이후 24시간으로 수정)
- 영상에서는 검증 기간 / 리포트 기간이 지났을 때 일괄적으로 업데이트되는 것처럼 보이지만 서버 재시작할 때 이미 기간이 초과된 검증들을 한 번에 업데이트 해서 그런 것이고, 서버 실행 중에 검증을 새로 생성하면 각각 기간이 지났을 때 바로 처리해줍니다.